### PR TITLE
TWON-17568-Reset At Kernel Panic

### DIFF
--- a/include/configs/mx6ullevk.h
+++ b/include/configs/mx6ullevk.h
@@ -14,7 +14,7 @@
 #include "mx6_common.h"
 #include <asm/imx-common/gpio.h>
 
-#define UBOOT_VERSION "v1.2.1"
+#define UBOOT_VERSION "v1.2.2"
 #define CONFIG_VERSION_VARIABLE
 
 /* uncomment for PLUGIN mode support */
@@ -152,7 +152,8 @@
 		"logo.hwtype=${hwtype} " \
 		"fsck.repair=yes " \
 		"roofstype=ext4 " \
-		"u-boot="UBOOT_VERSION"-"TWONAV_DEVICE"\0" \
+		"u-boot="UBOOT_VERSION"-"TWONAV_DEVICE" " \
+		"panic=30\0" \
 	"loadbootscript=" \
 		"load mmc ${mmcdev}:${mmcpart} ${loadaddr} ${script};\0" \
 	"bootscript=echo Running bootscript from mmc ...; " \


### PR DESCRIPTION
Device will be reseted 30 seconds after a kernel panic. This should avoid situations where power button doesn't respond.
@tpaschidis @faragon2n @dnietotwonav 