### PR TITLE
TWON-17605-TerraReboot

### DIFF
--- a/board/freescale/mx6ullevk/mx6ullevk.c
+++ b/board/freescale/mx6ullevk/mx6ullevk.c
@@ -429,15 +429,17 @@ error:
 	return;
 }
 
-#define WLAN_WL_ENABLE IMX_GPIO_NR(1, 29)
-#define WLAN_BT_ENABLE IMX_GPIO_NR(1, 30)
-#define WLAN_SWITCH IMX_GPIO_NR(1, 31)
+#define WLAN_WL_ENABLE 	IMX_GPIO_NR(1, 29)
+#define WLAN_BT_ENABLE 	IMX_GPIO_NR(1, 30)
+#define WLAN_SWITCH 	IMX_GPIO_NR(1, 31)
+#define RESET_TOUCH 	IMX_GPIO_NR(2, 7)
 
 static void setup_gpios(void)
 {
 	gpio_direction_output(WLAN_WL_ENABLE, 0);
 	gpio_direction_output(WLAN_BT_ENABLE, 0);
 	gpio_direction_output(WLAN_SWITCH, 0);
+	gpio_direction_output(RESET_TOUCH, 1);
 }
 
 #ifdef CONFIG_FSL_QSPI

--- a/include/configs/mx6ullevk.h
+++ b/include/configs/mx6ullevk.h
@@ -14,7 +14,7 @@
 #include "mx6_common.h"
 #include <asm/imx-common/gpio.h>
 
-#define UBOOT_VERSION "v1.2.2"
+#define UBOOT_VERSION "v1.2.3"
 #define CONFIG_VERSION_VARIABLE
 
 /* uncomment for PLUGIN mode support */


### PR DESCRIPTION
- Inits pcap reset gpio (2, 7) in reset state (output, 0) in order to ensure a
clean init when kernel starts. Kernel must put this gpio into high state in order
 to quit pcap reset state.

@dnietotwonav @faragon2n @tpaschidis 